### PR TITLE
Issue #18 Close menu on Mouseout of menu.

### DIFF
--- a/assets/themes/gilt/js/main.js
+++ b/assets/themes/gilt/js/main.js
@@ -91,6 +91,16 @@
         categoryMenu.show().focus();
       });
 
+    $('#subnav span menu#categories-menu')
+      .on('mouseover', function() {
+        categoryMenu.show().focus();
+      });
+
+    $('#subnav span menu#categories-menu')
+      .on('mouseout', function() {
+        categoryMenu.hide();
+      });
+
     $('body').on('click', function (e) {
       if (e.target.className !== 'categories') {
         categoryMenu.hide();


### PR DESCRIPTION
- Keeps menu open when mousing over menu. Hides it when mouse out.
- Still stays open if you mouse out of the anchor link. Couldn't find a
  perfect quick solution for that.