### PR TITLE
Qcon Talks Blog Post

### DIFF
--- a/_posts/2016-10-24-qcon-new-york-talks.md
+++ b/_posts/2016-10-24-qcon-new-york-talks.md
@@ -13,17 +13,25 @@ tags:
 - heather fleming
 ---
 
-# Watch Heather Fleimg and Ade Trenaman's QCon New York Talks 
+# Watch Heather Fleming and Ade Trenaman's QCon New York Talks 
 
-Held each year in June, QCon New York is one of the world's leading software development conferences. This year, we had two speakers from HBC Digital invited to present how our teams work and how we have leveraged containers. 
+Held each year in June, QCon New York is one of the world's leading software development conferences. This year, we had speakers from HBC Digital present how our teams work and how we have leveraged containers. 
 
 ## What we've learned about building great teams and improving team communication
+
+<p align="center">
+<img src="http://i.imgur.com/yUKhf3K.jpg">
+</p>
 
 Heather Fleming, our VP, People Operations & Product Delivery PMO, delivered a talk on two frameworks that can be used to improve communication, increase empathy and establish the psychologically safe environment a team needs to thrive. She also demonstrates how we build teams around initiatives using a “Team Ingredients” framework that focuses on each individual's strengths and talents and what they contribute to the team.
 
 ### Watch here: [How to Unlock the "Secret Sauce" of Great Teams](https://www.infoq.com/presentations/gilt-team-communication)
 
 ## What we've learned from using container technology at HBC Digital
+
+<p align="center">
+<img src="http://i.imgur.com/pOiOxT3.jpg">
+</p>
 
 Our SVP, Engineering Adrian Trenaman's talk provides detailed examples of how HBC Digital has used Docker and where container technology has paid off and, pragmatically, what aspects of the technology haven't panned out as they thought they would.
 

--- a/_posts/2016-10-24-qcon-new-york-talks.md
+++ b/_posts/2016-10-24-qcon-new-york-talks.md
@@ -15,23 +15,19 @@ tags:
 
 # Watch Heather Fleming and Ade Trenaman's QCon New York Talks 
 
+<p align="center">
+<img src="http://i.imgur.com/0T3BqJf.jpg">
+</p>
+
 Held each year in June, QCon New York is one of the world's leading software development conferences. This year, we had speakers from HBC Digital present how our teams work and how we have leveraged containers. 
 
 ## What we've learned about building great teams and improving team communication
-
-<p align="center">
-<img src="http://i.imgur.com/yUKhf3K.jpg">
-</p>
 
 Heather Fleming, our VP, People Operations & Product Delivery PMO, delivered a talk on two frameworks that can be used to improve communication, increase empathy and establish the psychologically safe environment a team needs to thrive. She also demonstrates how we build teams around initiatives using a “Team Ingredients” framework that focuses on each individual's strengths and talents and what they contribute to the team.
 
 ### Watch here: [How to Unlock the "Secret Sauce" of Great Teams](https://www.infoq.com/presentations/gilt-team-communication)
 
 ## What we've learned from using container technology at HBC Digital
-
-<p align="center">
-<img src="http://i.imgur.com/pOiOxT3.jpg">
-</p>
 
 Our SVP, Engineering Adrian Trenaman's talk provides detailed examples of how HBC Digital has used Docker and where container technology has paid off and, pragmatically, what aspects of the technology haven't panned out as they thought they would.
 

--- a/_posts/2016-10-24-qcon-new-york-talks.md
+++ b/_posts/2016-10-24-qcon-new-york-talks.md
@@ -1,0 +1,30 @@
+---
+layout: post
+title: "Watch Gilt's QCon New York talks"
+author: John Coghlan
+date: '2016-10-24'
+categories: 'conferences'
+tags:
+- communication
+- team building
+- containers
+- docker
+- adrian trenaman
+- heather fleming
+---
+
+# Watch Heather Fleimg and Ade Trenaman's QCon New York Talks 
+
+Held each year in June, QCon New York is one of the world's leading software development conferences. This year, we had two speakers from HBC Digital invited to present how our teams work and how we have leveraged containers. 
+
+## What we've learned about building great teams and improving team communication
+
+Heather Fleming, our VP, People Operations & Product Delivery PMO, delivered a talk on two frameworks that can be used to improve communication, increase empathy and establish the psychologically safe environment a team needs to thrive. She also demonstrates how we build teams around initiatives using a “Team Ingredients” framework that focuses on each individual's strengths and talents and what they contribute to the team.
+
+### Watch here: [How to Unlock the "Secret Sauce" of Great Teams](https://www.infoq.com/presentations/gilt-team-communication)
+
+## What we've learned from using container technology at HBC Digital
+
+Our SVP, Engineering Adrian Trenaman's talk provides detailed examples of how HBC Digital has used Docker and where container technology has paid off and, pragmatically, what aspects of the technology haven't panned out as they thought they would.
+
+### Watch here: [How Containers Have Panned Out](https://www.infoq.com/presentations/hbc-containers)


### PR DESCRIPTION
Heather and Ade gave talks in June at QCon New York. The conference released the videos over the course of a few months and Heather's video was part of the final release last week. This post will help visitors to our tech blog to easily find and watch the videos. 