### PR TITLE
Resolve incompatibility between JekyII Bootstrap and JekyII v.3.1

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -17,7 +17,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
-    {% endif %}  
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+    {% endif %}
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
I've receive the following e-mail:
```
The page build completed successfully, but returned the following warning:

You are currently using the Jekyll Bootstrap framework which has a known incompatibility 
with Jekyll v3.1. To fix this incompatibility, change `page.theme.name` in `_includes/JB/setup`
 to `layout.theme.name`. Your site may not build properly until this change has been applied.
 For more information, see http://jekyllrb.com/docs/upgrading/2-to-3/#layout-metadata.

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/troubleshooting-jekyll-builds

If you have any questions you can contact us by replying to this email.
```